### PR TITLE
fix: add repository metadata

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -8,5 +8,6 @@
       "extensions": [".dart"],
       "tokenize": "src/tokenizeDart.js"
     }
-  ]
+  ],
+  "repository": "https://github.com/lvce-editor/language-basics-dart"
 }


### PR DESCRIPTION
Adds the canonical GitHub repository URL to extension.json so the extension details view can link to the package source.